### PR TITLE
Tooltip at widget checkbox label

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -116,6 +116,9 @@
         {{ label|trans({}, translation_domain) }}
         {% if widget_checkbox_label == 'widget' %}
             {{ block('label_asterisk') }}
+            {% if help_label_tooltip_title %}
+                <a href="#" id="{{ id }}_tooltip" title="{{ help_label_tooltip_title|trans({}, translation_domain) }}" tabindex="-1" data-toggle="tooltip" data-placement="{{ help_label_tooltip_placement }}"><i class="{{ help_label_tooltip_icon }}"></i></a>
+            {% endif %}
         {% endif %}
     {% endif %}
     {% set help_inline = false %}


### PR DESCRIPTION
Added possibility to get tooltip at widget checkbox label:
![checkbox_tooltip](https://cloud.githubusercontent.com/assets/8894360/17936465/30f61d54-6a1f-11e6-8ffb-4c76a9c07438.png)
